### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/Grizzelbee/ioBroker.robonect.git"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
Adaptercode 3.x.x is known to fail when installed with node 14 as npm 6 does not install peer dependencies. So this adapter requires node 16 or newer